### PR TITLE
[testing needed] wpa_supplicant

### DIFF
--- a/usr/share/66/service/dhclient
+++ b/usr/share/66/service/dhclient
@@ -7,6 +7,6 @@
 
 
 [start]
-@execute = ( dhclient -d )
+@execute = ( dhclient -d -w )
 
 

--- a/usr/share/66/service/wpa_supplicant
+++ b/usr/share/66/service/wpa_supplicant
@@ -1,0 +1,28 @@
+[main]
+@type = classic
+@description = "WPA/WPA2/IEEE 802.1X Supplicant daemon"
+@version = @VERSION@
+@user = ( root )
+@options = ( log env )
+@hiercopy = ( wpa_supplicant-auto )
+
+[start]
+@build = custom
+@shebang = "/bin/sh"
+@execute = (
+exec 2>&1
+if [ -n "$CONF_FILE" ]; then
+	${OPTS:=-M -c ${CONF_FILE:-/etc/wpa_supplicant/wpa_supplicant.conf} ${WPA_INTERFACE:+-i ${WPA_INTERFACE}} ${DRIVER:+-D ${DRIVER}} -s}
+else
+	. ./wpa_supplicant-auto
+	OPTS="${AUTO} -s"
+fi
+
+exec wpa_supplicant ${OPTS} -s
+)
+
+[environment]
+CONF_FILE=
+WPA_INTERFACE=
+DRIVER=
+

--- a/usr/share/66/service/wpa_supplicant-auto
+++ b/usr/share/66/service/wpa_supplicant-auto
@@ -1,0 +1,15 @@
+# find interface from wpa_supplicant-*.conf files
+for f in /etc/wpa_supplicant/wpa_supplicant-*.conf \
+	/etc/wpa_supplicant-*.conf; do
+	case "$f" in *"/wpa_supplicant-*.conf") continue ;; esac
+	iface=${f#*/wpa_supplicant-}
+	if [ -z "$AUTO" ]; then
+		AUTO="${AUTO} -c ${f} -i ${iface%.conf}"
+	else
+		AUTO="${AUTO} -N -c ${f} -i ${iface%.conf}"
+	fi
+done
+
+# match all configuration
+[ -r /etc/wpa_supplicant/wpa_supplicant.conf ] &&
+	AUTO="${AUTO} -M -c /etc/wpa_supplicant/wpa_supplicant.conf"


### PR DESCRIPTION
@teldra  @flexibeast :
The wpa_supplicant frontend service file is heavily based on the voidlinux service. It copies wpa_supplicant-auto via `@hiercopy`, which has the same contents as the auto file, to the service dir.
The script in `@execute` checks is $CONF_FILE is set and if it is it uses $CONF_FILE, $WPA_INTERFACE and $DRIVER from [environment]. If it is not it uses the wpa_supplicant-auto.
I have only tested with $AUTO, using configuration generated by wpa_gui.
The change to dhclient may not be needed, but I had some curious behavior without it when I tried to plug my usb wifi stick into an already running system. I will try to see if it makes any real difference.
I will appreciate any help testing, as I have not really used wpa_supplicant for my machines.

