### PR TITLE
[WIP] first batch of user services

### DIFF
--- a/usr/share/66/service/deluge-web_us
+++ b/usr/share/66/service/deluge-web_us
@@ -1,0 +1,10 @@
+[main]
+@type = classic
+@description = "deluge webui daemon"
+@version = @VERSION@
+@user = ( user )
+@options = ( log )
+
+[start]
+@execute = ( deluge-web -d )
+

--- a/usr/share/66/service/deluged_us
+++ b/usr/share/66/service/deluged_us
@@ -1,0 +1,11 @@
+[main]
+@type = classic
+@description = "deluge daemon"
+@version = @VERSION@
+@user = ( user )
+@options = ( log )
+
+[start]
+@execute = ( deluged -d )
+
+

--- a/usr/share/66/service/qbittorrent-nox_us
+++ b/usr/share/66/service/qbittorrent-nox_us
@@ -1,0 +1,9 @@
+[main]
+@type = classic
+@version = @VERSION@
+@description = "qbittorent-nox daemon"
+@user = ( user )
+@options = ( log )
+
+[start]
+@execute = ( qbittorrent-nox )

--- a/usr/share/66/service/syncthing_us
+++ b/usr/share/66/service/syncthing_us
@@ -1,0 +1,12 @@
+[main]
+@type = classic
+@version = @VERSION@
+@description = "syncthing daemon"
+@user = ( user )
+@options = ( log env )
+
+[start]
+@execute = ( execl-cmdline -s { syncthing -no-restart ${cmd_args} } )
+
+[environment]
+cmd_args=!-no-browser

--- a/usr/share/66/service/transmission-daemon_us
+++ b/usr/share/66/service/transmission-daemon_us
@@ -1,0 +1,9 @@
+[main]
+@type = classic
+@version = @VERSION@
+@description = "transmission daemon"
+@user = ( user )
+@options = ( log )
+
+[start]
+@execute = ( transmission-daemon -f )


### PR DESCRIPTION
This is the first batch of frontends for user services. They have the suffix **_us** in their name and they only work in a user scandir. To test/use one must install and start a [scandir@](https://github.com/mobinmob/void-66-services/issues/19) service for a user and enable them in a user tree.
The syncthing_us service frontend file has two differences from the corresponding runit service:
1.  It uses stdout for logging (the default)
2. It does not start the webui in a browser when started.