### PR TITLE
unbound: use -dd instead of -d in order to

### DIFF
--- a/usr/share/66/service/unbound
+++ b/usr/share/66/service/unbound
@@ -6,4 +6,4 @@
 @options = ( log )
 
 [start]
-@execute = ( unbound -dp )
+@execute = ( unbound -ddp )


### PR DESCRIPTION
always log on stderr and prevent boot problems.