### PR TITLE
dbus: use polling to notify readiness

### DIFF
--- a/usr/share/66/service/dbus/data/check
+++ b/usr/share/66/service/dbus/data/check
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec dbus-send --system / org.freedesktop.DBus.Peer.Ping > /dev/null 2> /dev/null

--- a/usr/share/66/service/dbus/dbus
+++ b/usr/share/66/service/dbus/dbus
@@ -1,15 +1,14 @@
 [main]
 @type = longrun
-@version = 0.0.1
+@version = 0.0.2
 @description = "dbus system daemon"
 @user = ( root )
 @maxdeath = 3
-@notify = 4
-@options = ( log )
-@timeout-up = 3000
+@notify = 3
+@hiercopy = ( data )
 
 [start]
 @execute = (
 	execl-toc -d /run/dbus  -m 755 -g 22 -u 22
-	dbus-daemon --nofork --nopidfile --system --print-pid=4
+	exec s6-notifyoncheck dbus-daemon --nofork --system --nopidfile
 )


### PR DESCRIPTION
Test polling instead of using --print-pid for notification. I believe that right now it is the best choice - @st3r4g has compelling [arguments](https://github.com/st3r4g/void-s6/issues/3) and the implementation works.
The service has been tested, I will continue to do so. It is also the first service that includes an executable file (the data/check script) and has some directory structure. The makefile needs to adjust.