### PR TITLE
dcron : use 66-ns in order to work around the nosetsid issue.

### DIFF
--- a/usr/share/66/service/dcron
+++ b/usr/share/66/service/dcron
@@ -3,11 +3,7 @@
 @description = "dcron daemon"
 @version = 0.0.1 
 @user = ( root )
-@options = ( log )
-# https://github.com/dubiousjim/dcron/issues/13
-@flags = ( nosetsid )
+@notify = 3
 
 [start]
-@execute = ( dcrond -f )
-
-
+@execute = ( 66-ns -d 3 -o unshare=pid dcrond -f )


### PR DESCRIPTION
@flexibeast : Please test if you have the time. I use the new 66-ns tool to run dcrond in a new pid namespace. It seems to work here...

@Obarun : First use of 66-ns on the repo :)

Closes https://github.com/mobinmob/void-66-services/issues/54 .