### PR TITLE
New service: agetty@.

### DIFF
--- a/usr/share/66/service/agetty@
+++ b/usr/share/66/service/agetty@
@@ -1,0 +1,12 @@
+#The service takes a tty as @I, e.g. agetty@tty6
+[main]
+@type = classic
+@version = 0.0.1
+@description = "Launch agetty @ @I"
+@user = ( root )
+
+[start]
+@execute = ( execl-cmdline -s { agetty ${cmd_args} @I } )
+
+[environment]
+cmd_args=!-J 38400


### PR DESCRIPTION
This service is based on the tty-rc@service written by @Obarun, after a report to the 66 m-l from @fungilife that with the current boot-66serv scheme one cannot start a tty-rc@ instance in another tree.
It functions as busybox-getty@ does.