### PR TITLE
[NEEDS TESTING] dcron: stop spamming the log when sendmail is not available,

### DIFF
--- a/usr/share/66/service/dcron
+++ b/usr/share/66/service/dcron
@@ -7,4 +7,11 @@
 
 [start]
 # https://github.com/dubiousjim/dcron/issues/13
-@execute = ( 66-ns -d 3 -o unshare=pid dcrond -f )
+@execute = ( execl-cmdline -s { 66-ns -d 3 -o unshare=pid dcrond -f ${cmd_args} } )
+
+[environment]
+# -d enables the debug output, < -M /usr/bin/true> stops the repeated messages about
+# sendmail not being present. If one wants to use sendmail or any other mta, they can
+# remove < -M /usr/bin/true> or adjust it accordingly.
+cmd_args=!-d -M /usr/bin/true
+

--- a/usr/share/66/service/dcron
+++ b/usr/share/66/service/dcron
@@ -1,7 +1,7 @@
 [main]
 @type = classic
 @description = "dcron daemon"
-@version = 0.0.2
+@version = 0.0.3
 @user = ( root )
 @notify = 3
 


### PR DESCRIPTION
- add debug (-d) output by default to the logger
- stop dcrond from trying to use sendmail and failing
- document the options in a comment.

This is an attempt to fix https://github.com/mobinmob/void-66-services/issues/65 reported by @flexibeast. It works reliably on my machine, but seems to fail elsewere :( - it needs more testing...