### PR TITLE
isc-ntpd: fix the service,

### DIFF
--- a/usr/share/66/service/isc-ntpd
+++ b/usr/share/66/service/isc-ntpd
@@ -1,9 +1,11 @@
 [main]
 @type = classic
-@version = 0.0.1
+@version = 0.0.2
 @description = "ntpd daemon"
 @user = ( root )
-@options = ( log )
 
 [start]
-@execute = ( ntpd -g -u ntpd:ntpd )
+@execute = ( execl-cmdline -s { isc-ntpd -n -u ntpd:ntpd ${cmd_args} } )
+
+[environment]
+cmd_args=!-g


### PR DESCRIPTION
- use -n to stay in the foreground,
- send -g to the [environment] section,
- use the isc-ntpd executable,
- remove the options key.