### PR TITLE
New services: snooze (as a cron alternative).

### DIFF
--- a/usr/share/66/service/snooze-daily
+++ b/usr/share/66/service/snooze-daily
@@ -1,0 +1,16 @@
+[main]
+@type = classic
+@version = 0.0.1
+@description = "snooze-daily daemon"
+@user = ( root )
+
+[start]
+@build = custom
+@shebang = "/bin/sh"
+@execute = (
+exec 2>&1
+s6-mkdir -p -v /var/cache/snooze
+exec snooze -s 1d -t /var/cache/snooze/daily -- sh -c \
+	"test -d /etc/cron.daily && run-parts --lsbsysinit /etc/cron.daily; : > /var/cache/snooze/daily"
+  )
+

--- a/usr/share/66/service/snooze-hourly
+++ b/usr/share/66/service/snooze-hourly
@@ -1,0 +1,16 @@
+[main]
+@type = classic
+@version = 0.0.1
+@description = "snooze-hourly daemon"
+@user = ( root )
+
+[start]
+@build = custom
+@shebang = "/bin/sh"
+@execute = (
+exec 2>&1
+s6-mkdir -p -v /var/cache/snooze
+exec snooze -H \* -s 1h -t /var/cache/snooze/hourly -- sh -c \
+	"test -d /etc/cron.hourly && run-parts --lsbsysinit /etc/cron.hourly; : > /var/cache/snooze/hourly"
+  )
+

--- a/usr/share/66/service/snooze-montly
+++ b/usr/share/66/service/snooze-montly
@@ -1,0 +1,16 @@
+[main]
+@type = classic
+@version = 0.0.1
+@description = "snooze-monthly daemon"
+@user = ( root )
+
+[start]
+@build = custom
+@shebang = "/bin/sh"
+@execute = (
+exec 2>&1
+s6-mkdir -p -v /var/cache/snooze
+exec snooze -d 1 -s 28d -t /var/cache/snooze/monthly -- sh -c \
+	"test -d /etc/cron.monthly && run-parts --lsbsysinit /etc/cron.monthly; : > /var/cache/snooze/monthly"
+  )
+

--- a/usr/share/66/service/snooze-weekly
+++ b/usr/share/66/service/snooze-weekly
@@ -1,0 +1,16 @@
+[main]
+@type = classic
+@version = 0.0.1
+@description = "snooze-weekly daemon"
+@user = ( root )
+
+[start]
+@build = custom
+@shebang = "/bin/sh"
+@execute = (
+exec 2>&1
+s6-mkdir -p -v /var/cache/snooze
+exec snooze -w 0 -s 7d -t /var/cache/snooze/weekly -- sh -c \
+	"test -d /etc/cron.weekly && run-parts --lsbsysinit /etc/cron.weekly; : > /var/cache/snooze/weekly"
+  )
+


### PR DESCRIPTION
This PR contains 4 services, heavily based on the services contained in the snooze voidlinux package. They are built in order to use snooze as a cron alternative in a practical manner. The contents of the `@execute` key are copies of the voidlinux runit services with a few additions/changes: mkdir is replaced with s6-mkdir, the -v switch is used and the is redirection for the log is added.
@flexibeast This may be of interest :)