### PR TITLE
[WIP] New service: gdm.

### DIFF
--- a/usr/share/66/service/gdm
+++ b/usr/share/66/service/gdm
@@ -7,11 +7,7 @@
 
 [start]
 @execute = (
-  if {
-	execl-toc -d /run/gdm -m 0711
-	chown root:gdm /run/gdm
-  }
-  if  {	s6-sleep 1 s6-echo Starting gdm... } 
+  execl-toc -d /run/gdm -m 0711 -u root -g gdm
+   if  { s6-sleep 1 s6-echo Starting gdm... } 
    gdm
 )
-

--- a/usr/share/66/service/gdm
+++ b/usr/share/66/service/gdm
@@ -1,0 +1,17 @@
+[main]
+@type = longrun
+@version = 0.0.1
+@description = "gdm daemon"
+@user = ( root )
+@extdepends = ( dbus )
+
+[start]
+@execute = (
+  if {
+	execl-toc -d /run/gdm -m 0711
+	chown root:gdm /run/gdm
+  }
+  if  {	s6-sleep 1 s6-echo Starting gdm... } 
+   gdm
+)
+


### PR DESCRIPTION
The service needs more testing.
In a pc with an nvidia driver, one must have `needs_root_rights = yes` in `/etc/X11/Xwrapper.config` in order to start the daemon. Many thanks to @linuxergr who suggested the above.
