### PR TITLE
New service: uptimed.

### DIFF
--- a/usr/share/66/service/uptimed
+++ b/usr/share/66/service/uptimed
@@ -1,0 +1,8 @@
+[main]
+@type = classic
+@version = 0.0.1
+@description = "uptime daemon"
+@user = ( root )
+
+[start]
+@execute = ( uptimed -f )


### PR DESCRIPTION
This service diverges from the voidlinux runit one,
because it does not accept command switches. Everything
can be configured in the configuration file and the
upstream service definitions do not contain extra switches.