### PR TITLE
[needs testing] repo-wide: use execl-toc instead of mkdir in frontend service files.

### DIFF
--- a/usr/share/66/service/dnsmasq
+++ b/usr/share/66/service/dnsmasq
@@ -6,7 +6,7 @@
 
 [start]
 @execute = (
-	if { s6-mkdir -p -v /var/lib/misc }
+	execl-toc -d /var/lib/misc
 	execl-cmdline -s { dnsmasq -k -u dnsmasq -g dnsmasq ${cmd_args} } )
 
 [environment]

--- a/usr/share/66/service/smbd
+++ b/usr/share/66/service/smbd
@@ -5,5 +5,6 @@
 @user = ( root )
 
 [start]
-@execute = ( foreground { s6-mkdir -p /run/samba }
+@execute = (
+	execl-toc -d /run/samba
 	exec smbd -F -S --no-process-group )

--- a/usr/share/66/service/snooze-daily
+++ b/usr/share/66/service/snooze-daily
@@ -8,9 +8,9 @@
 @build = custom
 @shebang = "/bin/sh"
 @execute = (
-exec 2>&1
-s6-mkdir -p -v /var/cache/snooze
-exec snooze -s 1d -t /var/cache/snooze/daily -- sh -c \
+	exec 2>&1
+	execl-toc -d /var/cache/snooze
+	exec snooze -s 1d -t /var/cache/snooze/daily -- sh -c \
 	"test -d /etc/cron.daily && run-parts --lsbsysinit /etc/cron.daily; : > /var/cache/snooze/daily"
   )
 

--- a/usr/share/66/service/snooze-hourly
+++ b/usr/share/66/service/snooze-hourly
@@ -8,9 +8,9 @@
 @build = custom
 @shebang = "/bin/sh"
 @execute = (
-exec 2>&1
-s6-mkdir -p -v /var/cache/snooze
-exec snooze -H \* -s 1h -t /var/cache/snooze/hourly -- sh -c \
+	exec 2>&1
+	execl-toc -d /var/cache/snooze
+	exec snooze -H \* -s 1h -t /var/cache/snooze/hourly -- sh -c \
 	"test -d /etc/cron.hourly && run-parts --lsbsysinit /etc/cron.hourly; : > /var/cache/snooze/hourly"
   )
 

--- a/usr/share/66/service/snooze-montly
+++ b/usr/share/66/service/snooze-montly
@@ -8,9 +8,9 @@
 @build = custom
 @shebang = "/bin/sh"
 @execute = (
-exec 2>&1
-s6-mkdir -p -v /var/cache/snooze
-exec snooze -d 1 -s 28d -t /var/cache/snooze/monthly -- sh -c \
+	exec 2>&1
+	execl-toc -d /var/cache/snooze
+	exec snooze -d 1 -s 28d -t /var/cache/snooze/monthly -- sh -c \
 	"test -d /etc/cron.monthly && run-parts --lsbsysinit /etc/cron.monthly; : > /var/cache/snooze/monthly"
   )
 

--- a/usr/share/66/service/snooze-weekly
+++ b/usr/share/66/service/snooze-weekly
@@ -8,9 +8,9 @@
 @build = custom
 @shebang = "/bin/sh"
 @execute = (
-exec 2>&1
-s6-mkdir -p -v /var/cache/snooze
-exec snooze -w 0 -s 7d -t /var/cache/snooze/weekly -- sh -c \
+	exec 2>&1
+	execl-toc -d /var/cache/snooze
+	exec snooze -w 0 -s 7d -t /var/cache/snooze/weekly -- sh -c \
 	"test -d /etc/cron.weekly && run-parts --lsbsysinit /etc/cron.weekly; : > /var/cache/snooze/weekly"
   )
 


### PR DESCRIPTION
That is a change to promote consistency in the service frontend files.
With execl-toc a single command can be used for testing and creation of
directories and files.