### PR TITLE
dhclient: improve service.

### DIFF
--- a/usr/share/66/service/dhclient
+++ b/usr/share/66/service/dhclient
@@ -1,8 +1,11 @@
 [main]
 @type = classic
 @description = "dhclient daemon"
-@version = 0.0.2 
+@version = 0.0.3 
 @user = ( root )
 
 [start]
-@execute = ( dhclient -d -w )
+@execute = ( execl-cmdline -s { dhclient -d ${cmd_args} } )
+
+[environment]
+cmd_args=!-w


### PR DESCRIPTION
- use execl-cmdline to allow for more than one argument,
- use the [environment] section for extra arguments.