### PR TITLE
earlyoom for 66

### DIFF
--- a/usr/share/66/service/earlyoom
+++ b/usr/share/66/service/earlyoom
@@ -1,0 +1,11 @@
+[main]
+@type = classic
+@version = 0.0.1
+@description = "earlyoom daemon"
+@user = (root)
+
+[start]
+@execute = ( execl-cmdline -s { earlyoom ${command_args} }
+
+[environment]
+command_args=$EARLYOOM_ARGS


### PR DESCRIPTION
Proper operation of the service script has been confirmed as below, so it must be ready to merge:

- [root@voidlinux linuxer]# 66-inservice earlyoom
Name                  : earlyoom
Version               : 0.0.1
In tree               : default
Status                : enabled, up (pid 31075) 1234 seconds
Type                  : classic
Description           : earlyoom daemon
Source                : /etc/66/service/earlyoom
Live                  : /run/66/scandir/0/earlyoom
Dependencies          : earlyoom-log
External dependencies : None
Optional dependencies : None
Start script          :  earlyoom 
Stop script           : None
Environment source    : None
Environment file      : None
Log name              : earlyoom-log
Log destination       : /var/log/66/earlyoom
Log file              : 
2021-09-27 10:59:42.606890641  mem avail:    75 of  5740 MiB ( 1.32%), swap free: 2119 of 7157 MiB (29.62%)......
