### PR TITLE
tor: some fixes...

### DIFF
--- a/usr/share/66/service/tor
+++ b/usr/share/66/service/tor
@@ -1,8 +1,13 @@
 [main]
-@type = longrun
-@version = 0.0.2
+@type = classic
+@version = 0.0.3
 @description = "Anonymizing Overlay Network"
 @user = ( root tor )
 
 [start]
-@execute = ( tor --runasdaemon 0 )
+@execute = ( 
+	s6-softlimit -o ${MAX_OPEN_FILES}
+	tor --runasdaemon 0 )
+
+[environment]
+MAX_OPEN_FILES=16384


### PR DESCRIPTION
- change @type to classic from longrun
- use s6-softlimit to limit open files
(that is to have the same behavior as the void runit service).