### PR TITLE
seatd: update for new release.

### DIFF
--- a/usr/share/66/service/seatd
+++ b/usr/share/66/service/seatd
@@ -1,12 +1,12 @@
 [main]
-@type = classic
-@version = 0.0.2
+@type = longrun
+@version = 0.0.3
 @description = "seat daemon"
+@notify = 3
 @user = ( root )
 
 [start]
 @execute = ( execl-cmdline -s { seatd ${cmd_args} } )
 
 [environment]
-SEATD_LOGLEVEL=error
-cmd_args=!-g _seatd
+cmd_args=!-n 3 -g _seatd -l error


### PR DESCRIPTION
- the loglevel is now a cli agrument
- add agument -n 3 for s6 notification support
- change type to longrun and define @notify = 3